### PR TITLE
devices: fix incorrect names

### DIFF
--- a/builds/Pong.json
+++ b/builds/Pong.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "AgBKartikey",
       "oem": "Nothing",
-      "device": "Phone 2",
+      "device": "Nothing Phone 2",
       "filename": "EvolutionX-14.0-20241018-Pong-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/Pong/14/EvolutionX-14.0-20241018-Pong-v9.5-Official.zip/download",
       "timestamp": 1729232661,

--- a/builds/beryllium.json
+++ b/builds/beryllium.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Le Hong Duc (tedomi2705)",
       "oem": "Xiaomi",
-      "device": "POCO F1",
+      "device": "Xiaomi pocophone F1",
       "filename": "EvolutionX-14.0-20241031-beryllium-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/beryllium/14/EvolutionX-14.0-20241031-beryllium-v9.5-Official.zip/download",
       "timestamp": 1730321310,

--- a/builds/beyond0lte.json
+++ b/builds/beyond0lte.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Achille (0xSharkBoy)",
       "oem": "Samsung",
-      "device": "Galaxy S10e",
+      "device": "Samsung Galaxy S10e",
       "filename": "EvolutionX-14.0-20241011-beyond0lte-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/beyond0lte/14/EvolutionX-14.0-20241011-beyond0lte-v9.5-Official.zip/download",
       "timestamp": 1728635356,

--- a/builds/beyond1lte.json
+++ b/builds/beyond1lte.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Achille (0xSharkBoy)",
       "oem": "Samsung",
-      "device": "Galaxy S10",
+      "device": "Samsung Galaxy S10",
       "filename": "EvolutionX-14.0-20241011-beyond1lte-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/beyond1lte/14/EvolutionX-14.0-20241011-beyond1lte-v9.5-Official.zip/download",
       "timestamp": 1728639808,

--- a/builds/beyond2lte.json
+++ b/builds/beyond2lte.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Achille (0xSharkBoy)",
       "oem": "Samsung",
-      "device": "Galaxy S10 Plus",
+      "device": "Samsung Galaxy S10 Plus",
       "filename": "EvolutionX-14.0-20241011-beyond2lte-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/beyond2lte/14/EvolutionX-14.0-20241011-beyond2lte-v9.5-Official.zip/download",
       "timestamp": 1728641377,

--- a/builds/beyondx.json
+++ b/builds/beyondx.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Achille (0xSharkBoy)",
       "oem": "Samsung",
-      "device": "Galaxy S10 5G",
+      "device": "Samsung Galaxy S10 5G",
       "filename": "EvolutionX-14.0-20241011-beyondx-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/beyondx/14/EvolutionX-14.0-20241011-beyondx-v9.5-Official.zip/download",
       "timestamp": 1728642922,

--- a/builds/cepheus.json
+++ b/builds/cepheus.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Chema Funtan",
       "oem": "Xiaomi",
-      "device": "Mi 9",
+      "device": "Xiaomi Mi 9",
       "filename": "EvolutionX-14.0-20241012-cepheus-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/cepheus/14/EvolutionX-14.0-20241012-cepheus-v9.5-Official.zip/download",
       "timestamp": 1728728844,

--- a/builds/d1.json
+++ b/builds/d1.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Achille (0xSharkBoy)",
       "oem": "Samsung",
-      "device": "Galaxy Note 10",
+      "device": "Samsung Galaxy Note 10",
       "filename": "EvolutionX-14.0-20241011-d1-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/d1/14/EvolutionX-14.0-20241011-d1-v9.5-Official.zip/download",
       "timestamp": 1728644443,

--- a/builds/d2s.json
+++ b/builds/d2s.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Achille (0xSharkBoy)",
       "oem": "Samsung",
-      "device": "Galaxy Note 10 Plus",
+      "device": "Samsung Galaxy Note 10 Plus",
       "filename": "EvolutionX-14.0-20241011-d2s-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/d2s/14/EvolutionX-14.0-20241011-d2s-v9.5-Official.zip/download",
       "timestamp": 1728645974,

--- a/builds/d2x.json
+++ b/builds/d2x.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Achille (0xSharkBoy)",
       "oem": "Samsung",
-      "device": "Galaxy Note 10 Plus 5G",
+      "device": "Samsung Galaxy Note 10 Plus 5G",
       "filename": "EvolutionX-14.0-20241011-d2x-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/d2x/14/EvolutionX-14.0-20241011-d2x-v9.5-Official.zip/download",
       "timestamp": 1728647546,

--- a/builds/davinci.json
+++ b/builds/davinci.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Chema Funtan",
       "oem": "Xiaomi",
-      "device": "Mi 9t",
+      "device": "Xiaomi Mi 9t",
       "filename": "EvolutionX-14.0-20241012-davinci-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/davinci/14/EvolutionX-14.0-20241012-davinci-v9.5-Official.zip/download",
       "timestamp": 1728723207,

--- a/builds/f62.json
+++ b/builds/f62.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Achille (0xSharkBoy)",
       "oem": "Samsung",
-      "device": "Galaxy F62",
+      "device": "Samsung Galaxy F62",
       "filename": "EvolutionX-14.0-20241011-f62-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/f62/14/EvolutionX-14.0-20241011-f62-v9.5-Official.zip/download",
       "timestamp": 1728649052,

--- a/builds/tissot.json
+++ b/builds/tissot.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Joey Huab",
       "oem": "Xiaomi",
-      "device": "Mi A1",
+      "device": "Xiaomi Mi A1",
       "filename": "EvolutionX-14.0-20241010-tissot-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/tissot/14/EvolutionX-14.0-20241010-tissot-v9.5-Official.zip/download",
       "timestamp": 1728559522,

--- a/builds/venus.json
+++ b/builds/venus.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Joey Huab",
       "oem": "Xiaomi",
-      "device": "Mi 11",
+      "device": "Xiaomi Mi 11",
       "filename": "EvolutionX-14.0-20241024-venus-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/venus/14/EvolutionX-14.0-20241024-venus-v9.5-Official.zip/download",
       "timestamp": 1729765109,

--- a/builds/zippo.json
+++ b/builds/zippo.json
@@ -3,7 +3,7 @@
     {
       "maintainer": "Chema Funtan",
       "oem": "Lenovo",
-      "device": "Z6 Pro",
+      "device": "Lenovo Z6 Pro",
       "filename": "EvolutionX-14.0-20241012-zippo-v9.5-Official.zip",
       "download": "https://sourceforge.net/projects/evolution-x/files/zippo/14/EvolutionX-14.0-20241012-zippo-v9.5-Official.zip/download",
       "timestamp": 1728749522,


### PR DESCRIPTION
devices names modified: beryllium, cepheus, davinci, pong, tissot, venus, zippo, beyond0lte, beyond1lte, beyond2lte, beyondx, d1, d2s, d2x, f62