### PR TITLE
OTA: Correct maintainer name for Aston

### DIFF
--- a/builds/aston.json
+++ b/builds/aston.json
@@ -1,7 +1,7 @@
 {
   "response": [
     {
-      "maintainer": "Tejas Singh",
+      "maintainer": "Tejas Singh (tejas101k)",
       "oem": "OnePlus",
       "device": "12R / Ace 3",
       "filename": "EvolutionX-14.0-20241111-aston-v9.5-Vanilla-Official.zip",


### PR DESCRIPTION
* https://evolution-x.org/team shows two entries for the username "tejas101k" because the maintainer key in the aston.json file of udc-vanilla differs from the maintainer key in the other device JSON files.