### PR TITLE
OTA: Add Moto SM6225 family

### DIFF
--- a/builds/bathena.json
+++ b/builds/bathena.json
@@ -1,0 +1,29 @@
+{
+  "response": [
+    {
+      "maintainer": "Deivid Ignacio Parra (Deivid21)",
+      "currently_maintained": true,
+      "oem": "Motorola",
+      "device": "Defy 2021",
+      "filename": "EvolutionX-15.0-20250601-bathena-10.6-Official.zip",
+      "download": "https://sourceforge.net/projects/evolution-x/files/bathena/15/EvolutionX-15.0-20250601-bathena-10.6-Official.zip/download",
+      "timestamp": 1748758133,
+      "md5": "2d850d0970f6f748b9306e0bc8bf3283",
+      "sha256": "ffc0e89b5c1601d54a765e575f2bebc140c3009dd5cfa2fa05c6a3d52fb88d7d",
+      "size": 2295434256,
+      "version": "10.6",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-15-official-evolution-x-v10-6-for-motorola-defy-2021-bathena-20250601.4741422/",
+      "firmware": "",
+      "paypal": "https://www.paypal.me/Deivid21",
+      "github": "Deivid21",
+      "sourceforge": "blueice21",
+      "initial_installation_images": [
+        "boot",
+        "dtbo",
+        "recovery",
+        "vbmeta"
+      ]
+    }
+  ]
+}

--- a/builds/borneo.json
+++ b/builds/borneo.json
@@ -1,0 +1,29 @@
+{
+  "response": [
+    {
+      "maintainer": "Deivid Ignacio Parra (Deivid21)",
+      "currently_maintained": true,
+      "oem": "Motorola",
+      "device": "Moto G Power 2021",
+      "filename": "EvolutionX-15.0-20250601-borneo-10.6-Official.zip",
+      "download": "https://sourceforge.net/projects/evolution-x/files/borneo/15/EvolutionX-15.0-20250601-borneo-10.6-Official.zip/download",
+      "timestamp": 1748761832,
+      "md5": "35710b34f5ea32101e5319ad7e030327",
+      "sha256": "ba3e85386666afdf5056b37799eacae691e3d805bf5ae62c6bd2178cbf3606c3",
+      "size": 2306277270,
+      "version": "10.6",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-15-official-evolution-x-v10-6-for-moto-g-power-2021-borneo-20250601.4741424/",
+      "firmware": "",
+      "paypal": "https://www.paypal.me/Deivid21",
+      "github": "Deivid21",
+      "sourceforge": "blueice21",
+      "initial_installation_images": [
+        "boot",
+        "dtbo",
+        "recovery",
+        "vbmeta"
+      ]
+    }
+  ]
+}

--- a/builds/capri.json
+++ b/builds/capri.json
@@ -1,0 +1,30 @@
+{
+  "response": [
+    {
+      "maintainer": "Deivid Ignacio Parra (Deivid21)",
+      "currently_maintained": true,
+      "oem": "Motorola",
+      "device": "Moto G10 & G10 Power / Lenovo K13 Note",
+      "filename": "EvolutionX-15.0-20250602-capri-10.6-Official.zip",
+      "download": "https://sourceforge.net/projects/evolution-x/files/capri/15/EvolutionX-15.0-20250602-capri-10.6-Official.zip/download",
+      "timestamp": 1748835836,
+      "md5": "8194af2148a3ae678b831b3d5335cc54",
+      "sha256": "a317c5e65bbb6ee3ba510f6e28e632b1296487c62f63ff3997ec336d351eea92",
+      "size": 2262720760,
+      "version": "10.6",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-15-official-evolution-x-v10-6-for-moto-g10-g10-power-capri-20250602.4741434/",
+      "firmware": "",
+      "paypal": "https://www.paypal.me/Deivid21",
+      "github": "Deivid21",
+      "sourceforge": "blueice21",
+      "initial_installation_images": [
+        "boot",
+        "dtbo",
+        "vbmeta",
+        "vbmeta_system",
+        "vendor_boot"
+      ]
+    }
+  ]
+}

--- a/builds/caprip.json
+++ b/builds/caprip.json
@@ -1,0 +1,30 @@
+{
+  "response": [
+    {
+      "maintainer": "Deivid Ignacio Parra (Deivid21)",
+      "currently_maintained": true,
+      "oem": "Motorola",
+      "device": "Moto G30 / Lenovo K13 Pro",
+      "filename": "EvolutionX-15.0-20250602-caprip-10.6-Official.zip",
+      "download": "https://sourceforge.net/projects/evolution-x/files/caprip/15/EvolutionX-15.0-20250602-caprip-10.6-Official.zip/download",
+      "timestamp": 1748837393,
+      "md5": "1bdbef573fef0ef767ac5e3f9a59903f",
+      "sha256": "9606438f73c1777d42e60f301fed4000636179b69980ca3a0fd6aab558aa000c",
+      "size": 2261114915,
+      "version": "10.6",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-15-official-evolution-x-v10-6-for-moto-g30-caprip-20250602.4741437/",
+      "firmware": "",
+      "paypal": "https://www.paypal.me/Deivid21",
+      "github": "Deivid21",
+      "sourceforge": "blueice21",
+      "initial_installation_images": [
+        "boot",
+        "dtbo",
+        "vbmeta",
+        "vbmeta_system",
+        "vendor_boot"
+      ]
+    }
+  ]
+}

--- a/builds/cebu.json
+++ b/builds/cebu.json
@@ -1,0 +1,29 @@
+{
+  "response": [
+    {
+      "maintainer": "Deivid Ignacio Parra (Deivid21)",
+      "currently_maintained": true,
+      "oem": "Motorola",
+      "device": "Moto G9 Power / Lenovo K12 Pro",
+      "filename": "EvolutionX-15.0-20250601-cebu-10.6-Official.zip",
+      "download": "https://sourceforge.net/projects/evolution-x/files/cebu/15/EvolutionX-15.0-20250601-cebu-10.6-Official.zip/download",
+      "timestamp": 1748760283,
+      "md5": "81ea1cf4f5451eab27c9e4092fa5145f",
+      "sha256": "ad05f9927829d54efbfb7a094848463085549f6618cbfb791fd570bb9adb62d5",
+      "size": 2309763337,
+      "version": "10.6",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-15-official-evolution-x-v10-6-for-moto-g9-power-cebu-20250601.4741426/",
+      "firmware": "",
+      "paypal": "https://www.paypal.me/Deivid21",
+      "github": "Deivid21",
+      "sourceforge": "blueice21",
+      "initial_installation_images": [
+        "boot",
+        "dtbo",
+        "recovery",
+        "vbmeta"
+      ]
+    }
+  ]
+}

--- a/builds/devon.json
+++ b/builds/devon.json
@@ -1,0 +1,30 @@
+{
+  "response": [
+    {
+      "maintainer": "Deivid Ignacio Parra (Deivid21)",
+      "currently_maintained": true,
+      "oem": "Motorola",
+      "device": "Moto G32",
+      "filename": "EvolutionX-15.0-20250602-devon-10.6-Official.zip",
+      "download": "https://sourceforge.net/projects/evolution-x/files/devon/15/EvolutionX-15.0-20250602-devon-10.6-Official.zip/download",
+      "timestamp": 1748838297,
+      "md5": "aaec9ddfa645a1aa0da14366efccd294",
+      "sha256": "92276874f7cca8b2086a60a6949ffd21fd6fcea726db72974543a1efb593f7fd",
+      "size": 2231586478,
+      "version": "10.6",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-15-official-evolution-x-v10-6-for-moto-g32-devon-20250602.4741438/",
+      "firmware": "",
+      "paypal": "https://www.paypal.me/Deivid21",
+      "github": "Deivid21",
+      "sourceforge": "blueice21",
+      "initial_installation_images": [
+        "boot",
+        "dtbo",
+        "vbmeta",
+        "vbmeta_system",
+        "vendor_boot"
+      ]
+    }
+  ]
+}

--- a/builds/guam.json
+++ b/builds/guam.json
@@ -1,0 +1,29 @@
+{
+  "response": [
+    {
+      "maintainer": "Deivid Ignacio Parra (Deivid21)",
+      "currently_maintained": true,
+      "oem": "Motorola",
+      "device": "Moto E7 Plus & Lenovo K12",
+      "filename": "EvolutionX-15.0-20250601-guam-10.6-Official.zip",
+      "download": "https://sourceforge.net/projects/evolution-x/files/guam/15/EvolutionX-15.0-20250601-guam-10.6-Official.zip/download",
+      "timestamp": 1748763410,
+      "md5": "3f571658835da74c7f2747bf65bcf9e0",
+      "sha256": "8c9a2cc52ad82a784470d354309a57b772ec618fd6f3e29162d13eea977dd887",
+      "size": 2291901818,
+      "version": "10.6",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-15-official-evolution-x-v10-6-for-moto-e7-plus-guam-20250601.4741427/",
+      "firmware": "",
+      "paypal": "https://www.paypal.me/Deivid21",
+      "github": "Deivid21",
+      "sourceforge": "blueice21",
+      "initial_installation_images": [
+        "boot",
+        "dtbo",
+        "recovery",
+        "vbmeta"
+      ]
+    }
+  ]
+}

--- a/builds/guamp.json
+++ b/builds/guamp.json
@@ -1,0 +1,29 @@
+{
+  "response": [
+    {
+      "maintainer": "Deivid Ignacio Parra (Deivid21)",
+      "currently_maintained": true,
+      "oem": "Motorola",
+      "device": "Moto G9 & G9 Play / Lenovo K12 Note",
+      "filename": "EvolutionX-15.0-20250601-guamp-10.6-Official.zip",
+      "download": "https://sourceforge.net/projects/evolution-x/files/guamp/15/EvolutionX-15.0-20250601-guamp-10.6-Official.zip/download",
+      "timestamp": 1748755234,
+      "md5": "f4235885f8928034b692292d8ee7aa9c",
+      "sha256": "06b58d2a0f2202313b265a59fc35958a6f463ddcc1345abb331695143559f45b",
+      "size": 2297103962,
+      "version": "10.6",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-15-official-evolution-x-v10-6-for-moto-g9-g9-play-guamp-20250601.4741428/",
+      "firmware": "",
+      "paypal": "https://www.paypal.me/Deivid21",
+      "github": "Deivid21",
+      "sourceforge": "blueice21",
+      "initial_installation_images": [
+        "boot",
+        "dtbo",
+        "recovery",
+        "vbmeta"
+      ]
+    }
+  ]
+}

--- a/builds/hawao.json
+++ b/builds/hawao.json
@@ -1,0 +1,30 @@
+{
+  "response": [
+    {
+      "maintainer": "Deivid Ignacio Parra (Deivid21)",
+      "currently_maintained": true,
+      "oem": "Motorola",
+      "device": "Moto G42",
+      "filename": "EvolutionX-15.0-20250602-hawao-10.6-Official.zip",
+      "download": "https://sourceforge.net/projects/evolution-x/files/hawao/15/EvolutionX-15.0-20250602-hawao-10.6-Official.zip/download",
+      "timestamp": 1748832059,
+      "md5": "7573c620161df265b4c5a327c60fd04f",
+      "sha256": "5d87301dc6801a8c3c1d328ec06ae01d7118848adef365dd304af4a1f7faaed4",
+      "size": 2259499557,
+      "version": "10.6",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-15-official-evolution-x-v10-6-for-moto-g42-hawao-20250602.4741429/",
+      "firmware": "",
+      "paypal": "https://www.paypal.me/Deivid21",
+      "github": "Deivid21",
+      "sourceforge": "blueice21",
+      "initial_installation_images": [
+        "boot",
+        "dtbo",
+        "vbmeta",
+        "vbmeta_system",
+        "vendor_boot"
+      ]
+    }
+  ]
+}

--- a/builds/rhode.json
+++ b/builds/rhode.json
@@ -1,0 +1,30 @@
+{
+  "response": [
+    {
+      "maintainer": "Deivid Ignacio Parra (Deivid21)",
+      "currently_maintained": true,
+      "oem": "Motorola",
+      "device": "Moto G52",
+      "filename": "EvolutionX-15.0-20250602-rhode-10.6-Official.zip",
+      "download": "https://sourceforge.net/projects/evolution-x/files/rhode/15/EvolutionX-15.0-20250602-rhode-10.6-Official.zip/download",
+      "timestamp": 1748839306,
+      "md5": "b9fd900b8e7948b7cc9ab5db3add3393",
+      "sha256": "a88f35b8b8f692521eba0910f3305ff6b2eabe5a1533c0039b4a5290f6f67434",
+      "size": 2232175627,
+      "version": "10.6",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-15-official-evolution-x-v10-6-for-moto-g52-rhode-20250602.4741439/",
+      "firmware": "",
+      "paypal": "https://www.paypal.me/Deivid21",
+      "github": "Deivid21",
+      "sourceforge": "blueice21",
+      "initial_installation_images": [
+        "boot",
+        "dtbo",
+        "vbmeta",
+        "vbmeta_system",
+        "vendor_boot"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Motorola Defy 2021 (bathena)
- Moto E7 Plus (guam)
- Moto G9/G9 Play (guamp)
- Moto G9 Power (cebu)
- Moto G Power 2021 (borneo)
- Moto G10/G10 Power (capri)
- Moto G30 (caprip)
- Moto G32 (devon)
- Moto G42 (hawao)
- Moto G52 (rhode)