### PR TITLE
exynos9820: 08/31/2025 update

### DIFF
--- a/builds/beyond0lte.json
+++ b/builds/beyond0lte.json
@@ -1,0 +1,26 @@
+{
+  "response": [
+    {
+      "maintainer": "Achille (0xSharkBoy)",
+      "currently_maintained": true,
+      "oem": "Samsung",
+      "device": "Galaxy S10e",
+      "filename": "EvolutionX-16.0-20250829-beyond0lte-11.1-Official.zip",
+      "download": "https://cdn.evolution-x.org/beyond0lte/16/EvolutionX-16.0-20250829-beyond0lte-11.1-Official.zip/download",
+      "timestamp": 1756483608,
+      "md5": "a1c032565c7edae278fe293c70ef04b7",
+      "sha256": "1ff5051dbdbeeee7d8ff578ec006bb36f1bc2f41f32b0262b833fae01bd40bd7",
+      "size": 2503091203,
+      "version": "11.1",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-official-15-evolutionx-10-x-aosp-encryption.4669084/",
+      "firmware": "",
+      "paypal": "https://ko-fi.com/0xsharkboy",
+      "github": "0xsharkboy",
+      "initial_installation_images": [
+        "recovery"
+      ],
+      "extra_images": []
+    }
+  ]
+}

--- a/builds/beyond1lte.json
+++ b/builds/beyond1lte.json
@@ -1,0 +1,26 @@
+{
+  "response": [
+    {
+      "maintainer": "Achille (0xSharkBoy)",
+      "currently_maintained": true,
+      "oem": "Samsung",
+      "device": "Galaxy S10",
+      "filename": "EvolutionX-16.0-20250829-beyond1lte-11.1-Official.zip",
+      "download": "https://cdn.evolution-x.org/beyond1lte/16/EvolutionX-16.0-20250829-beyond1lte-11.1-Official.zip/download",
+      "timestamp": 1756488444,
+      "md5": "25da18ce9dbee8410fc515a4e43ab859",
+      "sha256": "26e884347308b3b676e7ebc0562d241079d990e364b4a3da66aacaf82f5a1b2d",
+      "size": 2640978270,
+      "version": "11.1",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-official-15-evolutionx-10-x-aosp-encryption.4669084/",
+      "firmware": "",
+      "paypal": "https://ko-fi.com/0xsharkboy",
+      "github": "0xsharkboy",
+      "initial_installation_images": [
+        "recovery"
+      ],
+      "extra_images": []
+    }
+  ]
+}

--- a/builds/beyond2lte.json
+++ b/builds/beyond2lte.json
@@ -1,0 +1,26 @@
+{
+  "response": [
+    {
+      "maintainer": "Achille (0xSharkBoy)",
+      "currently_maintained": true,
+      "oem": "Samsung",
+      "device": "Galaxy S10 Plus",
+      "filename": "EvolutionX-16.0-20250829-beyond2lte-11.1-Official.zip",
+      "download": "https://cdn.evolution-x.org/beyond2lte/16/EvolutionX-16.0-20250829-beyond2lte-11.1-Official.zip/download",
+      "timestamp": 1756475769,
+      "md5": "cd89483added7f4b16f4278186411165",
+      "sha256": "863edc30605e1d1268ac6415a0cef8f2ea158184f2fa2bdb6f9d6d7e3afbd7e7",
+      "size": 2641338352,
+      "version": "11.1",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-official-15-evolutionx-10-x-aosp-encryption.4669084/",
+      "firmware": "",
+      "paypal": "https://ko-fi.com/0xsharkboy",
+      "github": "0xsharkboy",
+      "initial_installation_images": [
+        "recovery"
+      ],
+      "extra_images": []
+    }
+  ]
+}

--- a/builds/beyondx.json
+++ b/builds/beyondx.json
@@ -1,0 +1,26 @@
+{
+  "response": [
+    {
+      "maintainer": "Achille (0xSharkBoy)",
+      "currently_maintained": true,
+      "oem": "Samsung",
+      "device": "Galaxy S10 5G",
+      "filename": "EvolutionX-16.0-20250829-beyondx-11.1-Official.zip",
+      "download": "https://cdn.evolution-x.org/beyondx/16/EvolutionX-16.0-20250829-beyondx-11.1-Official.zip/download",
+      "timestamp": 1756493420,
+      "md5": "b3a147983445e55f5a955ba1c66f6af9",
+      "sha256": "95730c88c52d9368f4e3c23e29e368d9fd0e4e614b90e84896b4c51493b015be",
+      "size": 2653853085,
+      "version": "11.1",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-official-15-evolutionx-10-x-aosp-encryption.4669084/",
+      "firmware": "",
+      "paypal": "https://ko-fi.com/0xsharkboy",
+      "github": "0xsharkboy",
+      "initial_installation_images": [
+        "recovery"
+      ],
+      "extra_images": []
+    }
+  ]
+}

--- a/builds/d1.json
+++ b/builds/d1.json
@@ -1,0 +1,26 @@
+{
+  "response": [
+    {
+      "maintainer": "Achille (0xSharkBoy)",
+      "currently_maintained": true,
+      "oem": "Samsung",
+      "device": "Galaxy Note 10",
+      "filename": "EvolutionX-16.0-20250829-d1-11.1-Official.zip",
+      "download": "https://cdn.evolution-x.org/d1/16/EvolutionX-16.0-20250829-d1-11.1-Official.zip/download",
+      "timestamp": 1756498370,
+      "md5": "9c3dfd0045d3b3be79622fa3264da6b9",
+      "sha256": "71641a49f96c821f603d103d11aaff58c345754e739ba60283064132cc990571",
+      "size": 2623957191,
+      "version": "11.1",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-official-15-evolutionx-10-x-aosp-encryption.4669086/",
+      "firmware": "",
+      "paypal": "https://ko-fi.com/0xsharkboy",
+      "github": "0xsharkboy",
+      "initial_installation_images": [
+        "recovery"
+      ],
+      "extra_images": []
+    }
+  ]
+}

--- a/builds/d2s.json
+++ b/builds/d2s.json
@@ -1,0 +1,26 @@
+{
+  "response": [
+    {
+      "maintainer": "Achille (0xSharkBoy)",
+      "currently_maintained": true,
+      "oem": "Samsung",
+      "device": "Galaxy Note 10 Plus",
+      "filename": "EvolutionX-16.0-20250829-d2s-11.1-Official.zip",
+      "download": "https://cdn.evolution-x.org/d2s/16/EvolutionX-16.0-20250829-d2s-11.1-Official.zip/download",
+      "timestamp": 1756503287,
+      "md5": "d1d2bb34a7273a10c0046400517ede0f",
+      "sha256": "e78086401842b6706748e78f3dacb5c6cb172feb49da0ad4ea2c99e134f06d59",
+      "size": 2627033905,
+      "version": "11.1",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-official-15-evolutionx-10-x-aosp-encryption.4669086/",
+      "firmware": "",
+      "paypal": "https://ko-fi.com/0xsharkboy",
+      "github": "0xsharkboy",
+      "initial_installation_images": [
+        "recovery"
+      ],
+      "extra_images": []
+    }
+  ]
+}

--- a/builds/d2x.json
+++ b/builds/d2x.json
@@ -1,0 +1,26 @@
+{
+  "response": [
+    {
+      "maintainer": "Achille (0xSharkBoy)",
+      "currently_maintained": true,
+      "oem": "Samsung",
+      "device": "Galaxy Note 10 Plus 5G",
+      "filename": "EvolutionX-16.0-20250830-d2x-11.1-Official.zip",
+      "download": "https://cdn.evolution-x.org/d2x/16/EvolutionX-16.0-20250830-d2x-11.1-Official.zip/download",
+      "timestamp": 1756508336,
+      "md5": "93d21c1c905dcfda7654d0c42c4876ee",
+      "sha256": "5fe38b16b6d413aa1b8ff51a7f584c42266ec02f12a9afc6cda6e4ae6f5cd6b0",
+      "size": 2666797590,
+      "version": "11.1",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-official-15-evolutionx-10-x-aosp-encryption.4669086/",
+      "firmware": "",
+      "paypal": "https://ko-fi.com/0xsharkboy",
+      "github": "0xsharkboy",
+      "initial_installation_images": [
+        "recovery"
+      ],
+      "extra_images": []
+    }
+  ]
+}

--- a/builds/f62.json
+++ b/builds/f62.json
@@ -1,0 +1,26 @@
+{
+  "response": [
+    {
+      "maintainer": "Achille (0xSharkBoy)",
+      "currently_maintained": true,
+      "oem": "Samsung",
+      "device": "Galaxy F62",
+      "filename": "EvolutionX-16.0-20250830-f62-11.1-Official.zip",
+      "download": "https://cdn.evolution-x.org/f62/16/EvolutionX-16.0-20250830-f62-11.1-Official.zip/download",
+      "timestamp": 1756513290,
+      "md5": "513f56042514c100bb4cc663da5bec91",
+      "sha256": "b6ab1940d1adaef31f682763760ad361c558d63b3effb37726e3c6627e2cad3d",
+      "size": 2515974637,
+      "version": "11.1",
+      "buildtype": "userdebug",
+      "forum": "https://xdaforums.com/t/rom-official-15-evolutionx-10-x-aosp-encryption.4669082/",
+      "firmware": "",
+      "paypal": "https://ko-fi.com/0xsharkboy",
+      "github": "0xsharkboy",
+      "initial_installation_images": [
+        "recovery"
+      ],
+      "extra_images": []
+    }
+  ]
+}

--- a/changelogs/beyond0lte.txt
+++ b/changelogs/beyond0lte.txt
@@ -1,0 +1,11 @@
+This is  Android 16 with August 2025 security patches
+
+Notes:
+==============================
+- LineageOS-based source. Signed build.
+- Dirty flash is fine over last build.
+- Includes Dolby Atmos.
+
+Device changes:
+==============================
+Initial Android 16 build

--- a/changelogs/beyond1lte.txt
+++ b/changelogs/beyond1lte.txt
@@ -1,0 +1,11 @@
+This is  Android 16 with August 2025 security patches
+
+Notes:
+==============================
+- LineageOS-based source. Signed build.
+- Dirty flash is fine over last build.
+- Includes Dolby Atmos.
+
+Device changes:
+==============================
+Initial Android 16 build

--- a/changelogs/beyond2lte.txt
+++ b/changelogs/beyond2lte.txt
@@ -1,0 +1,11 @@
+This is  Android 16 with August 2025 security patches
+
+Notes:
+==============================
+- LineageOS-based source. Signed build.
+- Dirty flash is fine over last build.
+- Includes Dolby Atmos.
+
+Device changes:
+==============================
+Initial Android 16 build

--- a/changelogs/beyondx.txt
+++ b/changelogs/beyondx.txt
@@ -1,0 +1,11 @@
+This is  Android 16 with August 2025 security patches
+
+Notes:
+==============================
+- LineageOS-based source. Signed build.
+- Dirty flash is fine over last build.
+- Includes Dolby Atmos.
+
+Device changes:
+==============================
+Initial Android 16 build

--- a/changelogs/d1.txt
+++ b/changelogs/d1.txt
@@ -1,0 +1,11 @@
+This is  Android 16 with August 2025 security patches
+
+Notes:
+==============================
+- LineageOS-based source. Signed build.
+- Dirty flash is fine over last build.
+- Includes Dolby Atmos.
+
+Device changes:
+==============================
+Initial Android 16 build

--- a/changelogs/d2s.txt
+++ b/changelogs/d2s.txt
@@ -1,0 +1,11 @@
+This is  Android 16 with August 2025 security patches
+
+Notes:
+==============================
+- LineageOS-based source. Signed build.
+- Dirty flash is fine over last build.
+- Includes Dolby Atmos.
+
+Device changes:
+==============================
+Initial Android 16 build

--- a/changelogs/d2x.txt
+++ b/changelogs/d2x.txt
@@ -1,0 +1,11 @@
+This is  Android 16 with August 2025 security patches
+
+Notes:
+==============================
+- LineageOS-based source. Signed build.
+- Dirty flash is fine over last build.
+- Includes Dolby Atmos.
+
+Device changes:
+==============================
+Initial Android 16 build

--- a/changelogs/f62.txt
+++ b/changelogs/f62.txt
@@ -1,0 +1,11 @@
+This is  Android 16 with August 2025 security patches
+
+Notes:
+==============================
+- LineageOS-based source. Signed build.
+- Dirty flash is fine over last build.
+- Includes Dolby Atmos.
+
+Device changes:
+==============================
+Initial Android 16 build


### PR DESCRIPTION
Automated group release update by 0xsharkboy.

Devices updated: beyond0lte, beyond1lte, beyond2lte, beyondx, d1, d2s, d2x, f62

Group: exynos9820