### PR TITLE
Release v20250917 for r8s

### DIFF
--- a/changelogs/r8s.md
+++ b/changelogs/r8s.md
@@ -1,0 +1,6 @@
+# r8s - v20250917
+
+
+
+Released: 2025-09-17
+Maintainer: objecting_


### PR DESCRIPTION

        **Device:** r8s
        **Version:** v20250917
        **Maintainer:** objecting_
        **Release Date:** 2025-09-17
        
        **Changelog:**
        
        
        **Test Status:** ⚠️ Not tested
        