### PR TITLE
Release v20250918 for rubyx

### DIFF
--- a/changelogs/rubyx.md
+++ b/changelogs/rubyx.md
@@ -1,0 +1,6 @@
+# rubyx - v20250918
+
+
+
+Released: 2025-09-18
+Maintainer: Aeron


### PR DESCRIPTION

        **Device:** rubyx
        **Version:** v20250918
        **Maintainer:** Aeron
        **Release Date:** 2025-09-18
        
        **Changelog:**
        
        
        **Test Status:** ⚠️ Not tested
        